### PR TITLE
Example for setting timeouts with Faraday.new

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,10 @@ Faraday.get(url) do |req|
   req.options.timeout = 1
   req.options.open_timeout = 1
 end
+
+Faraday.new(url, request: { timeout: 1, open_timeout: 1 }) do |faraday|
+  # ...
+end
 ```
 
 Raises


### PR DESCRIPTION
When using Faraday instances this might be the preferred way to get the timeouts to propagate to all your calls (in the instance)...

Great project btw!!!